### PR TITLE
Fix install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ To run this example, you will need to install the following:
 
 .. code-block:: bash
 
-    $ pip install ray[tune]
+    $ pip install "ray[tune]"
 
 
 This example runs a parallel grid search to optimize an example objective function.
@@ -155,7 +155,7 @@ RLlib Quick Start
 .. code-block:: bash
 
   pip install tensorflow  # or tensorflow-gpu
-  pip install ray[rllib]  # also recommended: ray[debug]
+  pip install "ray[rllib]"  # also recommended: ray[debug]
 
 .. code-block:: python
 


### PR DESCRIPTION
## Why are these changes needed?

Installation instructions, as provided, don't work in bash; brackets trigger a pattern matching (glob) operation. This change fixes that, and brings all pip install commands inline with the quoted form shown for ray serve: `pip install "ray[serve]"`

## Related issue number

None

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   NA
